### PR TITLE
Added internal redirect support

### DIFF
--- a/jobs/sslproxy/spec
+++ b/jobs/sslproxy/spec
@@ -2,6 +2,7 @@
 name: sslproxy
 templates:
   location.conf.erb: config/location.conf
+  location.internal_redirect.conf.erb: config/location.internal_redirect.conf
   mime.types: config/mime.types
   nginx.conf.erb: config/nginx.conf
   nginx_ctl: bin/nginx_ctl
@@ -49,6 +50,9 @@ properties:
     description: 'SSL private key (PEM encoded)'
   sslproxy.https.ssl_cert:
     description: 'SSL Certificate (PEM encoded)'
+  sslproxy.internal_redirect.enabled:
+    description: 'Enable/Disable internal redirects (X-Accel-Redirect)'
+    default: false
 
   router.port:
     description: 'Router port'

--- a/jobs/sslproxy/templates/location.conf.erb
+++ b/jobs/sslproxy/templates/location.conf.erb
@@ -1,3 +1,7 @@
+<% if p('sslproxy.internal_redirect.enabled') %>
+include /var/vcap/jobs/sslproxy/config/location.internal_redirect.conf;
+<% end %>
+
 location / {
   proxy_pass            http://router;
 

--- a/jobs/sslproxy/templates/location.internal_redirect.conf.erb
+++ b/jobs/sslproxy/templates/location.internal_redirect.conf.erb
@@ -1,0 +1,34 @@
+# Proxy download 
+location ~* ^/internal_redirect/(https?)/(.*?)/(.*) {
+  # Do not allow people to mess with this location directly
+  # Only internal redirects are allowed
+  internal;
+
+  # Location-specific logging
+  access_log /var/vcap/sys/log/sslproxy/internal_redirect.access.log;
+  error_log /var/vcap/sys/log/sslproxy/internal_redirect.error.log;
+
+  # Extract download url from the request
+  set $download_protocol $1;
+  set $download_host $2;
+  set $download_uri $3;
+
+  # Extract auth-token for swift
+  set $auth_token $upstream_http_x_auth_token;
+
+  # Compose download url
+  set $download_url $download_protocol://$download_host/$download_uri;
+
+  # Set download request headers
+  proxy_set_header Host $download_host;
+  proxy_set_header Authorization '';
+  proxy_set_header X-Auth-Token $auth_token;
+
+  # Do not touch local disks when proxying 
+  # content to clients
+  proxy_max_temp_file_size 0;
+
+  # Download the file and send it to client
+  proxy_pass $download_url;
+}
+


### PR DESCRIPTION
This pull request adds support for serving files stored in swift (or other blobstore) directly via nginx after your application has authorized the download. Full description of the problem can be found [here](http://kovyrin.net/2010/07/24/nginx-fu-x-accel-redirect-remote/).

The functionality can be disabled via `sslproxy.internal_redirect.enabled` which is `false` by default.

There are maybe better ways to solve this problem but we created the pull request to start the discussion with a working solution.
