### PR TITLE
Optionally redirect www-domains to bare domain

### DIFF
--- a/jobs/sslproxy/spec
+++ b/jobs/sslproxy/spec
@@ -53,6 +53,9 @@ properties:
   sslproxy.internal_redirect.enabled:
     description: 'Enable/Disable internal redirects (X-Accel-Redirect)'
     default: false
+  sslproxy.redirect_www:
+    description: 'Strip "www." and redirect'
+    default: false
 
   router.port:
     description: 'Router port'

--- a/jobs/sslproxy/templates/nginx.conf.erb
+++ b/jobs/sslproxy/templates/nginx.conf.erb
@@ -51,6 +51,13 @@ http {
 
     include /var/vcap/jobs/sslproxy/config/location.conf;
   }
+  <% if p('sslproxy.redirect_www') %>
+  server {
+    listen <%= p('sslproxy.http.port') %>;
+    server_name ~^www\.(.+)$;
+    return 301 http://$1<%= ":#{p('sslproxy.http.port')}" if p('sslproxy.http.port').to_s != '80' %>$request_uri;
+  }
+  <% end %>
   <% end %>
 
   server {
@@ -69,4 +76,11 @@ http {
 
     include /var/vcap/jobs/sslproxy/config/location.conf;
   }
+  <% if p('sslproxy.redirect_www') %>
+  server {
+    listen <%= p('sslproxy.https.port') %>;
+    server_name ~^www\.(.+)$;
+    return 301 https://$1<%= ":#{p('sslproxy.https.port')}" if p('sslproxy.https.port').to_s != '443' %>$request_uri;
+  }
+  <% end %>
 }


### PR DESCRIPTION
If you're in the [no-www camp](http://no-www.org) but still want to serve visitors that aren't, you can now optionally make Nginx redirect (301) a www-domain to its bare domain by setting the new `sslproxy.redirect_www` property to true (false by default).
#### Examples

```
https://www.example.org => https://example.org
https://www.example.org/any/thing => https://example.org/any/thing
https://www.example.org:445 => https://example.org:445
```

And if `sslproxy.http.enabled` is true:

```
http://www.example.org => http://example.org
http://www.example.org/any/thing => http://example.org/any/thing
http://www.example.org:8080 => http://example.org:8080
```
