### PR TITLE
add net-id to example configs

### DIFF
--- a/examples/dns-with-certificates.yml
+++ b/examples/dns-with-certificates.yml
@@ -27,6 +27,7 @@ networks:
   - name: default
     type: dynamic
     cloud_properties:
+      #net_id: <net-id> # specify net-id when openstack/neutron is running multiple networks
       security_groups:
         - sslproxy # CHANGE: Security group with ports 22, 80 & 443 open
 

--- a/examples/dns.yml
+++ b/examples/dns.yml
@@ -27,6 +27,7 @@ networks:
   - name: default
     type: dynamic
     cloud_properties:
+      #net_id: <net-id> # specify net-id when openstack/neutron is running multiple networks
       security_groups:
         - sslproxy # CHANGE: Security group with ports 22, 80 & 443 open
 


### PR DESCRIPTION
This is a very minor addition to the example configs that includes the "net-id" directive to use with openstack clusters that run multiple networks (e.g. external and internal).

When running openstack with multiple networks and a net-id isn't specified the following error will occur during the compilation phase during a deploy:

<pre>
update:
Preparing package compilation

Compiling packages
  nginx/1: OpenStack API Bad Request (Multiple possible networks found, use a Network ID to be more specific.). Check task debug log for details. (00:00:02)
Error                   1/1 00:00:02

Error 100: OpenStack API Bad Request (Multiple possible networks found, use a Network ID to be more specific.). Check task debug log for details.
</pre>
