### PR TITLE
Append 'server_port' to the proxy Host header

### DIFF
--- a/jobs/sslproxy/templates/location.conf.erb
+++ b/jobs/sslproxy/templates/location.conf.erb
@@ -10,7 +10,7 @@ location / {
   proxy_send_timeout    <%= p('sslproxy.proxy_send_timeout') %>;
 
   proxy_http_version    1.1;
-  proxy_set_header      Host              $host;
+  proxy_set_header      Host              $host:$server_port;
   proxy_set_header      X-Real-IP         $remote_addr;
   proxy_set_header      X-Forwarded-For   $proxy_add_x_forwarded_for;
   proxy_set_header      X-Forwarded-Proto $scheme;


### PR DESCRIPTION
We're supporting an application that facilitates authentication via CF's login server and we noticed that in order for the OAuth redirect URI to be set properly after successful login (for an application using thin server), the '$server_port' directive had to be appended to the '$host' proxy header in the sslproxy's nginx location.conf file. 

Without the '$server_port' directive being appended, the OAuth redirect URI will resolve to: /oauth/authorize?client_id=aportal&redirect_uri=**https**://example.com:**80** , resulting in a failed redirection and an ssl error being displayed in the browser since this redirect URI attempts an HTTPS request over port 80.

We noticed this behavior only with an application using thin server in conjunction with the login server. The same application using webrick redirected properly without the '$server_port' directive. Therefore, the '$server_port' isn't necessary for all cases, however, including it in the configuration doesn't appear to negatively affect other non-login related SSL requests.
