### PR TITLE
NGinx by default strips http headers containing underscore. 

### DIFF
--- a/jobs/sslproxy/templates/nginx.conf.erb
+++ b/jobs/sslproxy/templates/nginx.conf.erb
@@ -21,6 +21,8 @@ http {
   tcp_nopush         on;
   tcp_nodelay        on;
 
+  underscores_in_headers on;
+
   keepalive_timeout  <%= p('sslproxy.keepalive_timeout') %>;
   client_max_body_size <%= p('sslproxy.max_upload_size') %>;
 


### PR DESCRIPTION
This conservative choice for CGI mapping may break some apps relying on these valid headers

Instead buildpacks should handle these headers with underscore and reject them to protect CGI mapping if that is useful to the buildpack.

Details at http://wiki.nginx.org/Pitfalls#Missing_.28disappearing.29_HTTP_headers

"If you do not explicitly set underscores_in_headers on;, nginx will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). This is done in order to prevent ambiguities when mapping headers to CGI variables, as both dashes and underscores are mapped to underscores during that process.
"

http://stackoverflow.com/questions/22856136/why-underscores-are-forbidden-in-http-header-names
