### PR TITLE
Refining list of mime types on which the gzip compression is applied

### DIFF
--- a/jobs/sslproxy/templates/nginx.conf.erb
+++ b/jobs/sslproxy/templates/nginx.conf.erb
@@ -33,7 +33,7 @@ http {
   gzip_buffers       16 8k;
   gzip_comp_level    2;
   gzip_proxied       any;
-  gzip_types         text/plain text/css application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_types         application/json application/xml application/xhtml+xml application/javascript application/atom+xml application/rss+xml application/x-font-ttf application/x-javascript application/xml+rss image/svg+xml text/css text/javascript text/plain text/xml;
   gzip_vary          on;
   gzip_disable       "MSIE [1-6]\.(?!.*SV1)";
 


### PR DESCRIPTION
Note the application/rss+xml instead of application/xml+rss
